### PR TITLE
:sparkles: Add explainer dashboard watchdog listener

### DIFF
--- a/scripts/example.ipynb
+++ b/scripts/example.ipynb
@@ -1,0 +1,693 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4d15de38-8e46-4a0b-b54d-9068e02bfa4d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>#sk-container-id-1 {color: black;background-color: white;}#sk-container-id-1 pre{padding: 0;}#sk-container-id-1 div.sk-toggleable {background-color: white;}#sk-container-id-1 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-1 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-1 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-1 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-1 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-1 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-1 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-1 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-1 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-1 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-1 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-1 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-1 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-1 div.sk-item {position: relative;z-index: 1;}#sk-container-id-1 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-1 div.sk-item::before, #sk-container-id-1 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-1 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-1 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-1 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-1 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-1 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-1 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-1 div.sk-label-container {text-align: center;}#sk-container-id-1 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-1 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-1\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>RandomForestRegressor(max_depth=5, n_estimators=50)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-1\" type=\"checkbox\" checked><label for=\"sk-estimator-id-1\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">RandomForestRegressor</label><div class=\"sk-toggleable__content\"><pre>RandomForestRegressor(max_depth=5, n_estimators=50)</pre></div></div></div></div></div>"
+      ],
+      "text/plain": [
+       "RandomForestRegressor(max_depth=5, n_estimators=50)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from explainerdashboard import RegressionExplainer\n",
+    "from explainerdashboard import ClassifierExplainer\n",
+    "from explainerdashboard import ExplainerDashboard\n",
+    "\n",
+    "#Import the Diabetes Dataset\n",
+    "from sklearn.datasets import load_diabetes\n",
+    "data= load_diabetes()\n",
+    "X=pd.DataFrame(data.data,columns=data.feature_names)\n",
+    "y=pd.DataFrame(data.target,columns=[\"target\"])\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=1)\n",
+    "model = RandomForestRegressor(n_estimators=50, max_depth=5)\n",
+    "model.fit(X_train, y_train.values.ravel())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7ffcf547-f40d-4896-a9d6-2814025009c3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Changing class type to RandomForestRegressionExplainer...\n",
+      "Generating self.shap_explainer = shap.TreeExplainer(model)\n",
+      "Building ExplainerDashboard..\n",
+      "Detected notebook environment, consider setting mode='external', mode='inline' or mode='jupyterlab' to keep the notebook interactive while the dashboard is running...\n",
+      "Warning: calculating shap interaction values can be slow! Pass shap_interaction=False to remove interactions tab.\n",
+      "Generating layout...\n",
+      "Calculating shap values...\n",
+      "Calculating predictions...\n",
+      "Calculating residuals...\n",
+      "Calculating absolute residuals...\n",
+      "Calculating shap interaction values...\n",
+      "Reminder: TreeShap computational complexity is O(TLD^2), where T is the number of trees, L is the maximum number of leaves in any tree and D the maximal depth of any tree. So reducing these will speed up the calculation.\n",
+      "Calculating dependencies...\n",
+      "Calculating importances...\n",
+      "Calculating ShadowDecTree for each individual decision tree...\n",
+      "Reminder: you can store the explainer (including calculated dependencies) with explainer.dump('explainer.joblib') and reload with e.g. ClassifierExplainer.from_file('explainer.joblib')\n",
+      "Registering callbacks...\n",
+      "Dumping configuration .yaml to /home/sagemaker-user/dashboard-definitions/testing_tests.yaml...\n",
+      "Dumping explainer to /home/sagemaker-user/dashboard-definitions/testing_tests.joblib...\n",
+      "<STUDIO_URL>/jupyter/default/proxy/8056\n"
+     ]
+    }
+   ],
+   "source": [
+    "def submit_dashboard(name, port, explainer):\n",
+    "    '''Packages dashboard information and exports it into two files (yaml and joblib pair).\n",
+    "    The sagemaker lifecycle script starts a listener process that spins up explainer dashboards\n",
+    "    on the sagemaker system terminal.\n",
+    "    \n",
+    "    name: title for dashboard, also used for naming exported files\n",
+    "    port: the port on which sagemaker studio should spin up the dashboard\n",
+    "          (nothing will happen if the port is already in use)\n",
+    "    model: the model object (random forrest or whatever)'''\n",
+    "    \n",
+    "    DIRECTORY_TO_WATCH = \"/home/sagemaker-user/dashboard-definitions\"\n",
+    "    db = ExplainerDashboard(\n",
+    "        explainer,\n",
+    "        title=name,\n",
+    "        whatif=False,\n",
+    "        mode='dash',\n",
+    "        port=port,\n",
+    "        routes_pathname_prefix='/',\n",
+    "        requests_pathname_prefix=f'/jupyter/default/proxy/{port}/'\n",
+    "    )\n",
+    "\n",
+    "    # export dashboard files\n",
+    "    filename_prefix = name.replace(' ', '_').replace('.', '_')\n",
+    "    db.to_yaml(\n",
+    "        filepath=f\"{DIRECTORY_TO_WATCH}/{filename_prefix}.yaml\",\n",
+    "        explainerfile=f\"{DIRECTORY_TO_WATCH}/{filename_prefix}.joblib\",\n",
+    "        dump_explainer=True)\n",
+    "    print(f'<STUDIO_URL>/jupyter/default/proxy/{port}')\n",
+    "\n",
+    "    \n",
+    "\n",
+    "# explainer = ClassifierExplainer(model, X_test, y_test)\n",
+    "explainer = RegressionExplainer(model, X_test, y_test)\n",
+    "submit_dashboard('testing tests', 8056, explainer)"
+   ]
+  }
+ ],
+ "metadata": {
+  "availableInstances": [
+   {
+    "_defaultOrder": 0,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.t3.medium",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 1,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.t3.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 2,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.t3.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 3,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.t3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 4,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 5,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 6,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 7,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 8,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 9,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 10,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 11,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 12,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5d.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 13,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5d.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 14,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5d.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 15,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5d.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 16,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5d.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 17,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5d.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 18,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5d.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 19,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 20,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": true,
+    "memoryGiB": 0,
+    "name": "ml.geospatial.interactive",
+    "supportedImageNames": [
+     "sagemaker-geospatial-v1-0"
+    ],
+    "vcpuNum": 0
+   },
+   {
+    "_defaultOrder": 21,
+    "_isFastLaunch": true,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.c5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 22,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.c5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 23,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.c5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 24,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.c5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 25,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 72,
+    "name": "ml.c5.9xlarge",
+    "vcpuNum": 36
+   },
+   {
+    "_defaultOrder": 26,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 96,
+    "name": "ml.c5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 27,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 144,
+    "name": "ml.c5.18xlarge",
+    "vcpuNum": 72
+   },
+   {
+    "_defaultOrder": 28,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.c5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 29,
+    "_isFastLaunch": true,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g4dn.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 30,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g4dn.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 31,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g4dn.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 32,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g4dn.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 33,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g4dn.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 34,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g4dn.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 35,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 61,
+    "name": "ml.p3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 36,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 244,
+    "name": "ml.p3.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 37,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 488,
+    "name": "ml.p3.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 38,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.p3dn.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 39,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.r5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 40,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.r5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 41,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.r5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 42,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.r5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 43,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.r5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 44,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.r5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 45,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 512,
+    "name": "ml.r5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 46,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.r5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 47,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 48,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 49,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 50,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 51,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 52,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 53,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.g5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 54,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.g5.48xlarge",
+    "vcpuNum": 192
+   }
+  ],
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3 (lu-standard (lu-standard/latest)",
+   "language": "python",
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-west-1:409212678876:image/lu-standard"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -11,10 +11,11 @@ from explainerdashboard import ExplainerDashboard
 import threading
 from pathlib import Path
 
+logfile = "/tmp/dashboard-explainer-watchdog-listener-python-logging.log"
+
 def get_logger(logger_name: str = "script_logger") -> logging.Logger:
     """Returns the configured logger for the pipeline script"""
-    file_handler = logging.FileHandler(filename="pipeline.log")
-    
+    file_handler = logging.FileHandler(filename=logfile)
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
     handlers = [file_handler, stdout_handler]
 

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -46,10 +46,26 @@ class Watcher:
                 time.sleep(1)
         except:
             self.observer.stop()
-            logger.info("Error")
+            logger.info("Exiting - stopping threads")
+            for thread in threading.enumerate(): 
+                logger.info(f'{thread.name = }')
+                thread.join()
+            log_threads()
 
         self.observer.join()
 
+# TODO: remove log threads
+def log_threads():
+    logger.info('>>>>> Threads')
+    for thread in threading.enumerate(): 
+        logger.info(f'{thread.name = }\t{thread.is_alive() = }')
+
+# TODO: remove log files
+def log_files():
+    logger.info('>>>>> Files:')
+    for path in Path('.').iterdir(): 
+        logger.info(f'{path.name = }')
+    
 
 class Handler(FileSystemEventHandler):
 
@@ -57,12 +73,8 @@ class Handler(FileSystemEventHandler):
     def on_any_event(event):
         logger.info(f"{event.event_type} on: [{event.src_path}]")
 
-        # TODO: remove log threading
-        logger.info('>>>>> Threads')
-        for thread in threading.enumerate(): 
-            logger.info(
-                f'\t{thread.name = } {thread.is_alive() = } {thread.ident = } {thread.native_id = }'
-            )
+        log_files()
+        log_threads()
 
         if event.is_directory:
             return None
@@ -85,11 +97,12 @@ class Handler(FileSystemEventHandler):
             # TODO Treat edge case race condition when model file is read before yaml file
 
         elif event.event_type == 'modified':
-            # TODO reload explainerdashboard at port in config
+            # TODO stop explainerdashboard thread at port in config
             pass
 
         elif event.event_type == 'deleted':
             # TODO stop explainerdashboard at port in config; might need to map yaml config to port
+            
             pass
 
 

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -13,8 +13,8 @@ from pathlib import Path
 
 def get_logger(logger_name: str = "script_logger") -> logging.Logger:
     """Returns the configured logger for the pipeline script"""
-    file_handler = logging.FileHandler(filename=LOGS_PATH + "pipeline.log")
-
+    file_handler = logging.FileHandler(filename="pipeline.log")
+    
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
     handlers = [file_handler, stdout_handler]
 

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -63,7 +63,7 @@ class Handler(FileSystemEventHandler):
             return
         
         # ignore events that are not new files
-        if event.event_type is not 'created':
+        if event.event_type != 'created':
             return
         
         # ignore non yaml changes

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -67,7 +67,7 @@ class Handler(FileSystemEventHandler):
             return
         
         # ignore non yaml changes
-        if is_yml(event.src_path):
+        if not is_yml(event.src_path):
             return
 
         # it may take a second for the joblib (below) to be added

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -1,4 +1,37 @@
-# needs watchdog and explainer dashboard
+'''
+Watchdog listener demo adapted for explainer dashboard.
+
+## How it works
+
+The script is supposed to be in an S3 bucket which our SageMaker has access to.
+The script is fetched by a SageMaker lifecycle script and started as an asynchronous process with `nohup`. The lifecycle script is not included in this PR.
+
+### Listening Directory
+
+Once started, the script listens to changes in:
+`DIRECTORY_TO_WATCH = "/home/sagemaker-user/dashboard-definitions"`
+
+### Explainer Dashboard
+
+If the following event conditions are observed, the script will start an explainer dashboard in a separate thread:
+* file added
+* file is a yaml file
+* file has a corresponding joblib file
+
+The thread runs until it crashes or is shut down (i.e. explainer dashboard interface)
+
+### Log file
+
+The script outputs logs in:
+`logfile = "/tmp/dashboard-explainer-watchdog-listener-python-logging.log"`
+
+The nohup process may also pipe output to a logfile.
+
+### Trello Task
+
+**[implement-explainer-dashboard-watchdog](https://trello.com/c/wls37ubu/79-implement-explainer-dashboard-watchdog)**
+'''
+
 import time
 import os
 import sys

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -1,4 +1,4 @@
-'''
+"""
 Watchdog listener demo adapted for explainer dashboard.
 
 ## How it works
@@ -30,7 +30,7 @@ The nohup process may also pipe output to a logfile.
 ### Trello Task
 
 **[implement-explainer-dashboard-watchdog](https://trello.com/c/wls37ubu/79-implement-explainer-dashboard-watchdog)**
-'''
+"""
 
 import time
 import os
@@ -45,6 +45,7 @@ from pathlib import Path
 # constants
 DIRECTORY_TO_WATCH = "/home/sagemaker-user/dashboard-definitions"
 logfile = "/tmp/dashboard-explainer-watchdog-listener-python-logging.log"
+
 
 def get_logger(logger_name: str = "script_logger") -> logging.Logger:
     """Returns the configured logger for the pipeline script"""
@@ -63,7 +64,6 @@ def get_logger(logger_name: str = "script_logger") -> logging.Logger:
 
 
 class Watcher:
-
     def __init__(self):
         # self.observer = Observer()
         self.observer = PollingObserver()
@@ -78,15 +78,14 @@ class Watcher:
         except:
             self.observer.stop()
             logger.info("Exiting - stopping threads")
-            for thread in threading.enumerate(): 
-                logger.info(f'{thread.name = }')
+            for thread in threading.enumerate():
+                logger.info(f"{thread.name = }")
                 thread.join()
 
         self.observer.join()
 
 
 class Handler(FileSystemEventHandler):
-
     @staticmethod
     def on_any_event(event):
         logger.info(f"{event.event_type} on: [{event.src_path}]")
@@ -94,11 +93,11 @@ class Handler(FileSystemEventHandler):
         # ignore directory events
         if event.is_directory:
             return
-        
+
         # ignore events that are not new files
-        if event.event_type != 'created':
+        if event.event_type != "created":
             return
-        
+
         # ignore non yaml changes
         if not is_yml(event.src_path):
             return
@@ -113,35 +112,35 @@ class Handler(FileSystemEventHandler):
         # start dashboard
         file = extract_file(event.src_path)
         logger.info(f"Starting explainer dashboard thread for {file}")
-        threading.Thread(
-            target=lambda: ExplainerDashboard.from_config(file).run(),
-            name=file
-        ).start()
+        threading.Thread(target=lambda: ExplainerDashboard.from_config(file).run(), name=file).start()
+
 
 def is_yml(file):
-    '''check if a file extension is .yml'''
+    """check if a file extension is .yml"""
     return file.lower().endswith(".yaml")
 
+
 def extract_file(file):
-    '''extract file from a file path'''
+    """extract file from a file path"""
     return file.split("/")[-1]
 
+
 def has_corresponding_joblib(file_path):
-    '''check if a file with the same name but with the extension .joblib exists'''
-    return Path(file_path.replace('.yaml', '.joblib')).exists()
+    """check if a file with the same name but with the extension .joblib exists"""
+    return Path(file_path.replace(".yaml", ".joblib")).exists()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logger = get_logger()
 
     if not Path(DIRECTORY_TO_WATCH).exists():
-        logger.info('making directory:', DIRECTORY_TO_WATCH)
+        logger.info("making directory:", DIRECTORY_TO_WATCH)
         Path(DIRECTORY_TO_WATCH).mkdir()
 
-    logger.info(f'changing into: {DIRECTORY_TO_WATCH}')
+    logger.info(f"changing into: {DIRECTORY_TO_WATCH}")
     os.chdir(DIRECTORY_TO_WATCH)
 
     # start watcher
-    logger.info('starting watcher')
+    logger.info("starting watcher")
     w = Watcher()
     w.run()

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -1,0 +1,83 @@
+#needs watchdog and explainer dashboard
+import time
+import os
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+from watchdog.events import PatternMatchingEventHandler
+from watchdog.events import FileSystemEventHandler
+from explainerdashboard import ExplainerDashboard
+import threading
+from pathlib import Path
+
+DIRECTORY_TO_WATCH = "/home/sagemaker-user/dashboard-definitions"
+print('hello')
+
+if not Path(DIRECTORY_TO_WATCH).exists():
+    print('making directory:', DIRECTORY_TO_WATCH)
+    Path(DIRECTORY_TO_WATCH).mkdir()
+
+class Watcher:
+
+    def __init__(self):
+        # self.observer = Observer()
+        self.observer = PollingObserver()
+
+    def run(self):
+        event_handler = Handler()
+        self.observer.schedule(event_handler, DIRECTORY_TO_WATCH, recursive=True)
+        self.observer.start()
+        try:
+            while True:
+                time.sleep(5)
+        except:
+            self.observer.stop()
+            print("Error")
+
+        self.observer.join()
+
+
+class Handler(FileSystemEventHandler):
+
+    @staticmethod
+    def on_any_event(event):
+        print(
+            f"[{time.asctime()}] noticed {event.event_type} on: [{event.src_path}]"
+        )
+        if event.is_directory:
+            return None
+
+        elif event.event_type == 'created':
+            time.sleep(5)
+            print("Error")
+            # Take any action here when a file is first created.
+            print("Received created event - %s." % event.src_path)
+
+            file = extract_file(event.src_path)
+
+            if is_yml(file):
+                print("Starting explainer dashboard")
+                threading.Thread(target=lambda: ExplainerDashboard.from_config(file).run()).start()
+
+            # TODO Treat edge case race condition when model file is read before yaml file
+
+        elif event.event_type == 'modified':
+            # TODO reload explainerdashboard at port in config
+            print("Received modified event - %s." % event.src_path)
+
+        elif event.event_type == 'deleted':
+            # TODO stop explainerdashboard at port in config; might need to map yaml config to port
+            print("Received deleted event - %s." % event.src_path)
+
+#function to check if a file extension is .yml
+def is_yml(file):
+    return file.endswith(".yml") or file.endswith(".yaml")
+
+#function to extract file from a file path
+def extract_file(file):
+    return file.split("/")[-1]       
+
+if __name__ == '__main__':
+    os.chdir(DIRECTORY_TO_WATCH)
+    print('starting watcher')
+    w = Watcher()
+    w.run()

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -129,6 +129,10 @@ if __name__ == '__main__':
     logger.info(f'changing into: {DIRECTORY_TO_WATCH}')
     os.chdir(DIRECTORY_TO_WATCH)
 
+    # TODO remove startup logging
+    log_files()
+    log_threads()
+
     # start watcher
     logger.info('starting watcher')
     w = Watcher()

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -90,22 +90,17 @@ class Handler(FileSystemEventHandler):
     def on_any_event(event):
         logger.info(f"{event.event_type} on: [{event.src_path}]")
 
-        # ignore directory events
         if event.is_directory:
             return
 
-        # ignore events that are not new files
         if event.event_type != "created":
             return
 
-        # ignore non yaml changes
         if not is_yml(event.src_path):
             return
 
-        # it may take a second for the joblib (below) to be added
         time.sleep(1)
 
-        # ignore yaml additions without joblib
         if not has_corresponding_joblib(event.src_path):
             return
 

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -93,7 +93,7 @@ def extract_file(file):
 
 def has_corresponding_joblib(file_path):
     '''check if a file with the same name but with the extension .joblib exists'''
-    return Path(file_path.replace('.yaml', '.joblib')).exist()
+    return Path(file_path.replace('.yaml', '.joblib')).exists()
 
 
 if __name__ == '__main__':

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -32,7 +32,7 @@ logger = get_logger()
 logger.info('starting dashboard listener')
 
 DIRECTORY_TO_WATCH = "/home/sagemaker-user/dashboard-definitions"
-logger.info('hello'):
+logger.info('hello')
 
 if not Path(DIRECTORY_TO_WATCH).exists():
     logger.info('making directory:', DIRECTORY_TO_WATCH)

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -1,7 +1,5 @@
-
-
 def submit_dashboard(name, port, model, X_test, y_test):
-    dashboard_name = 'yeet'
+    dashboard_name = "yeet"
     explainer = RegressionExplainer(model, X_test, y_test)
 
     DIRECTORY_TO_WATCH = "/home/sagemaker-user/dashboard-definitions"
@@ -9,16 +7,13 @@ def submit_dashboard(name, port, model, X_test, y_test):
         explainer,
         title=name,
         whatif=False,
-        mode='dash',
+        mode="dash",
         port=port,
-        routes_pathname_prefix='/',
-        requests_pathname_prefix=f'/jupyter/default/proxy/{PORT}/'
+        routes_pathname_prefix="/",
+        requests_pathname_prefix=f"/jupyter/default/proxy/{PORT}/",
     )
 
-    filename = name.replace(' ', '_').replace('.', '_')
+    filename = name.replace(" ", "_").replace(".", "_")
 
-    db.to_yaml(
-        filepath=f"{DIRECTORY_TO_WATCH}/{filename}.yaml",
-        explainerfile=f"{DIRECTORY_TO_WATCH}/{filename}.joblib",
-        dump_explainer=True)
-    print(f'<STUDIO_URL>/jupyter/default/proxy/{port}')
+    db.to_yaml(filepath=f"{DIRECTORY_TO_WATCH}/{filename}.yaml", explainerfile=f"{DIRECTORY_TO_WATCH}/{filename}.joblib", dump_explainer=True)
+    print(f"<STUDIO_URL>/jupyter/default/proxy/{port}")

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -1,0 +1,24 @@
+
+
+def submit_dashboard(name, port, model, X_test, y_test):
+    dashboard_name = 'yeet'
+    explainer = RegressionExplainer(model, X_test, y_test)
+
+    DIRECTORY_TO_WATCH = "/home/sagemaker-user/dashboard-definitions"
+    db = ExplainerDashboard(
+        explainer,
+        title=name,
+        whatif=False,
+        mode='dash',
+        port=port,
+        routes_pathname_prefix='/',
+        requests_pathname_prefix=f'/jupyter/default/proxy/{PORT}/'
+    )
+
+    filename = name.replace(' ', '_').replace('.', '_')
+
+    db.to_yaml(
+        filepath=f"{DIRECTORY_TO_WATCH}/{filename}.yaml",
+        explainerfile=f"{DIRECTORY_TO_WATCH}/{filename}.joblib",
+        dump_explainer=True)
+    print(f'<STUDIO_URL>/jupyter/default/proxy/{port}')


### PR DESCRIPTION
Anamaria's watchdog listener demo adapted for explainer dashboard.

## How it works

The script is supposed to be in an S3 bucket which our SageMaker has access to.
The script is fetched by a SageMaker lifecycle script and started as an asynchronous process with `nohup`. The lifecycle script is not included in this PR.

### Listening Directory

Once started, the script listens to changes in:
`DIRECTORY_TO_WATCH = "/home/sagemaker-user/dashboard-definitions"`

### Explainer Dashboard

If the following event conditions are observed, the script will start an explainer dashboard in a separate thread:
* file added
* file is a yaml file
* file has a corresponding joblib file

The thread runs until it crashes or is shut down (i.e. explainer dashboard interface)

### Log file

The script outputs logs in:
`logfile = "/tmp/dashboard-explainer-watchdog-listener-python-logging.log"`

The nohup process may also pipe output to a logfile.

### Trello Task

**[implement-explainer-dashboard-watchdog](https://trello.com/c/wls37ubu/79-implement-explainer-dashboard-watchdog)**


## Try it!

First, restart your sagemaker instance (`file -> shut down -> shut down all`).
Then follow the [example notebook](https://github.com/Lundbeck-Biometrics/explainerdashboard/blob/185b2c5d3d5dc3c16c459d88b0281137ea30020b/scripts/example.ipynb)! 
